### PR TITLE
Use correct event for slider update

### DIFF
--- a/src/view/frontend/templates/layer/navigation-slider.phtml
+++ b/src/view/frontend/templates/layer/navigation-slider.phtml
@@ -73,7 +73,7 @@ $noUiSliderUrl = $block->getViewFileUrl('Emico_TweakwiseHyva::js/lib/nouislider.
                     }
                 });
 
-                slider.noUiSlider.on('update', (values) => {
+                slider.noUiSlider.on('slide', (values) => {
                     const minValue = values[0] * this.step;
                     const maxValue = values[1] * this.step;
                     this.updateLabels(minValue, maxValue);


### PR DESCRIPTION
Uses the correct event for the noUiSlider so it's not updated on initialisation.
This fixes the unwanted removal of the prices filter when unchecking the product name filter.

Closes #4 