### PR TITLE
Fix subsuggestion search

### DIFF
--- a/src/view/frontend/templates/html/header/search-form.phtml
+++ b/src/view/frontend/templates/html/header/search-form.phtml
@@ -52,7 +52,9 @@ $helper = $this->helper(SearchHelper::class);
                     .then(result => this.suggestions = result)
             },
             clickSuggestion(suggestion) {
-                if (suggestion.type === 'product') {
+                if (suggestion.type === 'suggestion_group') {
+                    return
+                } else if (suggestion.type === 'product') {
                     this.goToProduct(suggestion.url)
                 } else {
                     this.search(suggestion.title)
@@ -85,18 +87,18 @@ $helper = $this->helper(SearchHelper::class);
 </script>
 <div class="container py-2 mx-auto text-black" x-data="tweakwiseQuickSearch()">
     <form class="form minisearch relative" id="search_mini_form"
-          action="<?= $escaper->escapeUrl($helper->getResultUrl()) ?>" method="get">
+          action="<?=$escaper->escapeUrl($helper->getResultUrl())?>" method="get">
         <label class="hidden" for="search" data-role="minisearch-label">
-            <span><?= $escaper->escapeHtml(__('Search')) ?></span>
+            <span><?=$escaper->escapeHtml(__('Search'))?></span>
         </label>
         <input id="search"
                x-ref="searchInput"
                type="search"
                autocomplete="off"
-               name="<?= $escaper->escapeHtmlAttr($helper->getQueryParamName()) ?>"
-               value="<?= $escaper->escapeHtmlAttr($helper->getEscapedQueryText()) ?>"
-               placeholder="<?= $escaper->escapeHtmlAttr(__('Search entire store here...')) ?>"
-               maxlength="<?= $escaper->escapeHtmlAttr($helper->getMaxQueryLength()) ?>"
+               name="<?=$escaper->escapeHtmlAttr($helper->getQueryParamName())?>"
+               value="<?=$escaper->escapeHtmlAttr($helper->getEscapedQueryText())?>"
+               placeholder="<?=$escaper->escapeHtmlAttr(__('Search entire store here...'))?>"
+               maxlength="<?=$escaper->escapeHtmlAttr($helper->getMaxQueryLength())?>"
                class="w-full p-2 text-lg leading-normal transition appearance-none text-grey-800
                 focus:outline-none focus:border-transparent lg:text-xl"
                @focus.once="suggest"
@@ -104,13 +106,13 @@ $helper = $this->helper(SearchHelper::class);
                @click.away="close"
                @keydown.arrow-down.prevent="focusElement($el.querySelector('[tabindex]'))"
         />
-        <?= $block->getChildHtml('tweakwise.quick.search'); ?>
+        <?=$block->getChildHtml('tweakwise.quick.search');?>
         <button type="submit"
-                title="<?= $escaper->escapeHtml(__('Search')) ?>"
+                title="<?=$escaper->escapeHtml(__('Search'))?>"
                 class="action search sr-only"
                 aria-label="Search"
         >
-            <?= $escaper->escapeHtml(__('Search')) ?>
+            <?=$escaper->escapeHtml(__('Search'))?>
         </button>
     </form>
 </div>

--- a/src/view/frontend/templates/quick-search.phtml
+++ b/src/view/frontend/templates/quick-search.phtml
@@ -85,8 +85,11 @@ use Magento\Framework\View\Element\Template;
                                     <div class="qs-option w-full flex justify-between bg-container-lighter even:bg-container p-2 cursor-pointer border-t first-of-type:border-t-0 border-container hover:bg-container-darker"
                                          role="option"
                                          tabindex="0"
+                                         :data-title="suggestion.title ? suggestion.title : ''"
                                          @click="clickSuggestion(subSuggestion)"
                                          @keydown.enter="clickSuggestion(subSuggestion)"
+                                         @keydown.arrow-up.prevent="focusElement($event.target.previousElementSibling)"
+                                         @keydown.arrow-down.prevent="focusElement($event.target.nextElementSibling)"
                                     >
                                         <span class="qs-option-name" x-text="subSuggestion.title"></span>
                                         <span aria-hidden="true" class="amount"


### PR DESCRIPTION
Do not fire search action for the suggestion group parent, instead search for the suggestion option itself.

Closes #14 