### PR TITLE
Fix  category url for newer tweakwise versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "magento/framework": "*",
         "hyva-themes/magento2-compat-module-fallback": "*",
-        "emico/tweakwise": "*"
+        "emico/tweakwise": ">=4.0.6."
     },
     "authors": [{
         "name": "Emico B.V.",

--- a/src/view/frontend/templates/product/layered/link/item.phtml
+++ b/src/view/frontend/templates/product/layered/link/item.phtml
@@ -19,7 +19,7 @@ $item = $block->getItem();
 ?>
 
 <li class="item">
-    <a href="<?= $escaper->escapeUrl($item->getUrl()) ?>" class="flex w-full py-1 mb-1 hover:text-black">
+    <a href="<?= $block->getCategoryUrl($item) ?>" class="flex w-full py-1 mb-1 hover:text-black">
         <?= $block->getItemPrefix() ?>
         <?= $escaper->escapeHtml($item->getLabel()) ?>
         <?= $block->getItemPostfix() ?>


### PR DESCRIPTION
The category url in the hyva thema is not correct when using emico/tweakwise version 4.0.6 or newer. This results in double category names in the url when clicking a category in the filter bar. 

This pull request fixes that. Instead of using relative url's, use category urls with the domain name included.