### PR TITLE
Use caching setting for personal merchandising

### DIFF
--- a/src/view/frontend/templates/layer/navigation-form.phtml
+++ b/src/view/frontend/templates/layer/navigation-form.phtml
@@ -30,6 +30,7 @@ use Magento\Framework\View\Element\Template;
             isLoading: false,
             currentXhr: null,
             fetchController: null,
+            ajaxCache: true,
             init(initialValues) {
                 const filterOptions = initialValues.tweakwiseNavigationForm;
 
@@ -200,9 +201,9 @@ use Magento\Framework\View\Element\Template;
                 this.fetchController = new AbortController();
                 const signal = this.fetchController.signal
 
-                const options = {
+                let options = {
                     signal: signal,
-                    cache: 'force-cache'
+                    cache: this.ajaxCache ? 'default' : 'no-cache'
                 }
 
                 this.currentXhr = fetch(fetchUrl, options)


### PR DESCRIPTION
When using personal merchandising, the ajax request must not be cached because the catalog changes based on the viewed products.

This is already fixed in the tweakwise module. This pull request also fixes it in the hyva theme.

Note, this fix only works in combination with an pull request on the tweakwise module.

https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/253