### PR TITLE
Get correct slider config

### DIFF
--- a/src/view/frontend/templates/layer/navigation-slider.phtml
+++ b/src/view/frontend/templates/layer/navigation-slider.phtml
@@ -32,7 +32,7 @@ $noUiSliderUrl = $block->getViewFileUrl('Emico_TweakwiseHyva::js/lib/nouislider.
             ajaxFilters: false,
             urlInputSelector: 'input.slider-url-value',
             init(initialValues) {
-                const sliderOptions = initialValues.tweakwiseNavigationSlider;
+                const sliderOptions = Object.values(initialValues)[0];
 
                 if (sliderOptions) {
                     this.ajaxFilters = sliderOptions.ajaxFilters;


### PR DESCRIPTION
Due to these [changes](https://github.com/EmicoEcommerce/Magento2Tweakwise/commit/6a4be7cfda46b5eaa283768048f48f1740ca7cef#diff-d2021c2c0946899bdda24f1348cdbcb04329adf04e605735b6251f3b10abc22e) made in the main Tweakwise module where the object keys for the slider configuration has been changed, the (price) sliders are not provided with the correct configuration. This resulted in faulty slider min/max values:

[screencast-www.zitmaxx.nl-2022.08.31-16_02_50.webm](https://user-images.githubusercontent.com/16681244/187697734-7254a557-a98f-4aa5-ac42-fc4c439132ac.webm)

This fix makes sure the correct config is loaded independent from the used key.